### PR TITLE
Copy TCP option

### DIFF
--- a/nf_deaf.c
+++ b/nf_deaf.c
@@ -98,6 +98,7 @@ nf_deaf_tcp_init(struct tcphdr *th, const struct tcphdr *oth,
 	th->res1 = 0;
 	th->doff = NF_DEAF_TCP_DOFF;
 	tcp_flag_byte(th) = tcp_flag_byte(oth);
+	th->window = oth->window;
 	th->check = 0;
 	th->urg_ptr = 0;
 

--- a/nf_deaf.c
+++ b/nf_deaf.c
@@ -103,7 +103,7 @@ nf_deaf_tcp_init(struct tcphdr *th, const struct tcphdr *oth,
 	th->urg_ptr = 0;
 
 	data = (void *)th + sizeof(*th);
-	data[0] = htons(0x1312);
+	// data[0] = htons(0x1312);
 	data[9] = 0;
 	memcpy(data + NF_DEAF_TCP_DOFF, buf, payloadsize);
 }

--- a/nf_deaf.c
+++ b/nf_deaf.c
@@ -101,10 +101,11 @@ nf_deaf_tcp_init(struct tcphdr *th, const struct tcphdr *oth,
 	th->window = oth->window;
 	th->check = 0;
 	th->urg_ptr = 0;
-
+	memset((char*)th + sizeof(*th), 0, th->doff*4 - sizeof(*th));
+	
 	data = (void *)th + sizeof(*th);
 	// data[0] = htons(0x1312);
-	data[9] = 0;
+	// data[9] = 0;
 	memcpy(data + NF_DEAF_TCP_DOFF, buf, payloadsize);
 }
 

--- a/nf_deaf.c
+++ b/nf_deaf.c
@@ -120,32 +120,20 @@ static struct sk_buff *
 nf_deaf_alloc_and_init_skb(const struct sk_buff *oskb, unsigned int l3hdrsize, unsigned int payloadsize)
 {
 	struct dst_entry *dst;
-	unsigned int mac_len;
-	unsigned char *mac_ptr;
 	struct sk_buff *skb;
 
-	mac_len = skb_network_header(oskb) - skb_mac_header(oskb);
-	skb = alloc_skb(LL_MAX_HEADER + mac_len + l3hdrsize + NF_DEAF_TCP_DOFF*4 + payloadsize + 16, GFP_ATOMIC);
+	skb = alloc_skb(LL_MAX_HEADER + l3hdrsize + NF_DEAF_TCP_DOFF * 4 + payloadsize + 32, GFP_ATOMIC);
 	if (unlikely(!skb))
 		return NULL;
 
 	skb_reserve(skb, LL_MAX_HEADER);
-	if (mac_len) {
-        mac_ptr = skb_push(skb, mac_len);
-        skb_reset_mac_header(skb);
-        memcpy(mac_ptr, skb_mac_header(oskb), mac_len);
-    }
-	__skb_put(skb, mac_len + l3hdrsize + NF_DEAF_TCP_DOFF*4 + payloadsize);
+	__skb_put(skb, l3hdrsize + NF_DEAF_TCP_DOFF * 4 + payloadsize);
 	skb_copy_queue_mapping(skb, oskb);
 	dst = dst_clone(skb_dst(oskb));
-	if (!dst || IS_ERR(dst)) {
-        kfree_skb(skb);
-        return NULL;
-    }
 	skb->dev = dst->dev;
 	skb_dst_set(skb, dst);
 	skb_reset_network_header(skb);
-	skb_set_transport_header(skb, mac_len + l3hdrsize);
+	skb_set_transport_header(skb, l3hdrsize);
 
 	return skb;
 }


### PR DESCRIPTION
听说被运营商识别了，TCP这个0x1312的option太显眼了，本来应该只有时间戳的，给改成复制之前包的选项了。另外0 window也很可疑，改为复制原来包的window了。我本地测试没问题，请斧正。